### PR TITLE
[swipe-back] Allow swipe back on opposite gesture without lifting finger

### DIFF
--- a/install
+++ b/install
@@ -1,5 +1,11 @@
 #!/bin/bash
 DIR=$(dirname $0)
+
+if [ -x "$(command -v git)" ]; then
+    # stop any running comfortable-swipe if it exists
+    comfortable-swipe stop
+fi
+
 #copy config file
 mkdir -p ~/.config
 DCONF_PATH=$DIR/src/defaults.conf


### PR DESCRIPTION
Allow activation of a command with the opposite gesture without lifting fingers. A good use case of this is when you shift to the right workspace just to take a peek then back to the left without needing to lift the fingers.

Possible future tasks:
- enable/disable certain opposite gesture pairs (e.g. enable 3-finger left/right but disable 3-finger up/down)
- flag a different threshold for "opposite gestures"