### PR TITLE
Defer to bash when executing autostart script

### DIFF
--- a/install
+++ b/install
@@ -1,9 +1,10 @@
 #!/bin/bash
 DIR=$(dirname $0)
+PROGRAM=$HOME/.local/bin/comfortable-swipe
 
 if [ -x "$(command -v git)" ]; then
     # stop any running comfortable-swipe if it exists
-    comfortable-swipe stop
+    $PROGRAM stop
 fi
 
 #copy config file
@@ -29,5 +30,10 @@ else
 fi
 echo "Installing..."
 mkdir -p ~/.local/bin
-g++ -std=c++11 -O2 $DIR/src/comfortable-swipe.cpp -lxdo -o $HOME/.local/bin/comfortable-swipe || exec echo "Installation aborted"
+g++ -std=c++11 -O2 $DIR/src/comfortable-swipe.cpp -lxdo -o $PROGRAM || exec echo "Installation aborted"
+
+# toggle autostart twice to refresh any changes
+$PROGRAM autostart > /dev/null || exec echo "Installation aborted"
+$PROGRAM autostart > /dev/null || exec echo "Installation aborted"
+
 echo "Successfully installed. You may now run 'comfortable-swipe start'."

--- a/src/comfortable-swipe.cpp
+++ b/src/comfortable-swipe.cpp
@@ -31,6 +31,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <ctime>
 #include <unistd.h>
 #define cstr const string&
+#define PROGRAM "$HOME/.local/bin/comfortable-swipe"
 using namespace std;
 
 extern "C" {
@@ -267,7 +268,7 @@ namespace service {
     }
     // starts service
     void start() {
-        int x = system("stdbuf -oL -eL libinput-debug-events | $HOME/.local/bin/comfortable-swipe buffer");
+        int x = system("stdbuf -oL -eL libinput-debug-events | " PROGRAM " buffer");
     }
     // stops service
     void stop() {
@@ -316,7 +317,7 @@ namespace service {
                 fout <<
                     "[Desktop Entry]\n"
                     "Type=Application\n"
-                    "Exec=comfortable-swipe start\n"
+                    "Exec=bash -c \"" PROGRAM " start\"\n"
                     "Hidden=false\n"
                     "NoDisplay=false\n"
                     "X-GNOME-Autostart-enabled=true\n"


### PR DESCRIPTION
PATH is not reliable especially for .zshrc when running autostart script. Prefer executing autostart from bash by default instead. Fixes autostart bug is present in KDE neon v5.11 (plasma v5.11.2).