### PR TITLE
Optimize Regex patterns

### DIFF
--- a/src/comfortable-swipe.cpp
+++ b/src/comfortable-swipe.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** args) {
 }
 
 struct swipe_gesture {
-    string device, stamp, fingers;
+    string fingers;
     string dx, dy, udx, udy;
     xdo_t* xdo;
     virtual void on_update() = 0;
@@ -234,32 +234,26 @@ namespace service {
             auto data = sentence.data();
             cmatch matches;
             if (regex_match(data, matches, gesture_begin)) {
-               swipe.device = matches[1];
-               swipe.stamp = matches[2];
-               swipe.fingers = matches[3];
+               swipe.fingers = matches[1];
                swipe.on_begin();
             }
             else if (regex_match(data, matches, gesture_end)) {
-               swipe.device = matches[1];
-               swipe.stamp = matches[2];
-               swipe.fingers = matches[3];
+               swipe.fingers = matches[1];
                swipe.on_end();
             }
             else if (regex_match(data, matches, gesture_update)) {
-               swipe.device = matches[1];
-               swipe.stamp = matches[2];
-               swipe.fingers = matches[3];
-               swipe.dx = matches[4];
-               swipe.dy = matches[5];
-               swipe.udx = matches[6];
-               swipe.udy = matches[7];
+               swipe.fingers = matches[1];
+               swipe.dx = matches[2];
+               swipe.dy = matches[3];
+               swipe.udx = matches[4];
+               swipe.udy = matches[5];
                swipe.on_update();
             }
         }
     }
     // starts service
     void start() {
-        int x = system("stdbuf -oL -eL libinput debug-events | " PROGRAM " buffer");
+        int x = system("stdbuf -oL -e0 libinput debug-events | " PROGRAM " buffer");
     }
     // stops service
     void stop() {
@@ -342,41 +336,43 @@ namespace util {
     }
 
     string join(cstr delim, string arr[], int n) {
-        string ans = arr[0];
+        string ans = "^\\s*" + arr[0];
         for (int i = 1; i < n; ++i) {
             ans += delim;
             ans += arr[i];
         }
+        ans += "\\s*$";
         return ans;
     }
 
     string build_gesture_begin() {
-        string device = "\\s*(\\S+)\\s*";
-        string gesture = "\\s*GESTURE_SWIPE_BEGIN\\s*";
-        string seconds = "\\s*(\\S+)\\s*";
-        string fingers = "\\s*(\\d+)\\s*";
+        string device = "\\S+";
+        string gesture = "GESTURE_SWIPE_BEGIN";
+        string seconds = "\\S+";
+        string fingers = "(\\d+)";
         string arr[] = {device, gesture, seconds, fingers};
         return join("\\s+", arr, 4);
     }
 
     string build_gesture_update() {
-        string device = "\\s*(\\S+)\\s*";
-        string gesture = "\\s*GESTURE_SWIPE_UPDATE\\s*";
-        string seconds = "\\s*(\\S+)\\s*";
-        string fingers = "\\s*(\\d+)\\s*";
-        string num_1 = "\\s*(" + number_regex() + ")\\s*";
+        string device = "\\S+";
+        string gesture = "GESTURE_SWIPE_UPDATE";
+        string seconds = "\\S+";
+        string fingers = "(\\d+)";
+        string num_1 = "\\s*(" + number_regex() + ")";
         string num_2 = num_1;
         string num_div = num_1 + "/" + num_2;
-        string num_accel = "\\s*\\(\\s*" + num_div + "\\s*unaccelerated\\s*\\)\\s*";
+        string num_accel = "\\(" + num_div + "\\s+unaccelerated\\)";
         string arr[] = {device, gesture, seconds, fingers, num_div, num_accel};
-        return join("\\s+", arr, 6);
+        string result = join("\\s+", arr, 6);
+        return result;
     }
 
     string build_gesture_end() {
-        string device = "\\s*(\\S+)\\s*";
-        string gesture = "\\s*GESTURE_SWIPE_END\\s*";
-        string seconds = "\\s*(\\S+)\\s*";
-        string fingers = "\\s*(\\d+)\\s*";
+        string device = "\\S+";
+        string gesture = "GESTURE_SWIPE_END";
+        string seconds = "\\S+";
+        string fingers = "(\\d+)";
         string arr[] = {device, gesture, seconds, fingers};
         return join("\\s+", arr, 4);
     }

--- a/src/comfortable-swipe.cpp
+++ b/src/comfortable-swipe.cpp
@@ -206,14 +206,17 @@ namespace service {
 }
 
 namespace service {    
+
+    // process regex at compile time
+    const regex gesture_begin(util::GESTURE_SWIPE_BEGIN_REGEX_PATTERN);
+    const regex gesture_update(util::GESTURE_SWIPE_UPDATE_REGEX_PATTERN);
+    const regex gesture_end(util::GESTURE_SWIPE_END_REGEX_PATTERN);
+
     // parses output from libinput debug-events
     void buffer() {
         // check first if $user
         ios::sync_with_stdio(false);
         cin.tie(0); cout.tie(0);
-        const regex gesture_begin(util::GESTURE_SWIPE_BEGIN_REGEX_PATTERN);
-        const regex gesture_update(util::GESTURE_SWIPE_UPDATE_REGEX_PATTERN);
-        const regex gesture_end(util::GESTURE_SWIPE_END_REGEX_PATTERN);
         string sentence;
         // read config file
         auto config = util::read_config_file(conf_filename().data());
@@ -252,7 +255,7 @@ namespace service {
     }
     // starts service
     void start() {
-        int x = system("stdbuf -oL -e0 libinput debug-events | " PROGRAM " buffer");
+        int x = system("stdbuf -oL -eL libinput debug-events | " PROGRAM " buffer");
     }
     // stops service
     void stop() {
@@ -380,14 +383,14 @@ namespace util {
      *                                          fingers  dx   dy    udx   udy
      */
     const char* GESTURE_SWIPE_UPDATE_REGEX_PATTERN =
-        "^\\s*"                                            // trim start of string
-        "\\s+event\\d+"                                    // event
-        "\\s+GESTURE_SWIPE_UPDATE"                         // gesture
-        "\\s+\\S+"                                         // timestamp
-        "\\s+(\\d+)"                                       // fingers
+        "^\\s*"                                             // trim start of string
+        "\\s+event\\d+"                                     // event
+        "\\s+GESTURE_SWIPE_UPDATE"                          // gesture
+        "\\s+\\S+"                                          // timestamp
+        "\\s+(\\d+)"                                        // fingers
         "\\s+" CF_NUMBER_DIVISION                           // speed (dx/dy)
-        "\\s+\\(" CF_NUMBER_DIVISION "\\s+unaccelerated\\)"  // unaccelerated speed (udx/udy)
-        "\\s*$"                                            // trim end of string
+        "\\s+\\(" CF_NUMBER_DIVISION "\\s+unaccelerated\\)" // unaccelerated speed (udx/udy)
+        "\\s*$"                                             // trim end of string
     ;
 
     // delete macros

--- a/src/comfortable-swipe.cpp
+++ b/src/comfortable-swipe.cpp
@@ -343,12 +343,12 @@ namespace util {
      *                                        fingers
      */
     const char* GESTURE_SWIPE_BEGIN_REGEX_PATTERN =
-        "^\\s*"                    // trim start of string
-        "\\s+event\\d+"            // event
+        "^"                        // start of string
+        "[ -]event\\d+"            // event
         "\\s+GESTURE_SWIPE_BEGIN"  // gesture
         "\\s+\\S+"                 // timestamp
         "\\s+(\\d+)"               // fingers
-        "\\s*$"                    // trim end of string
+        "$"                        // end of string
     ;
 
     /**
@@ -360,12 +360,12 @@ namespace util {
      *                                        fingers
      */
     const char* GESTURE_SWIPE_END_REGEX_PATTERN =
-        "^\\s*"                    // trim start of string
-        "\\s+event\\d+"            // event
+        "^"                        // start of string
+        "[ -]event\\d+"            // event
         "\\s+GESTURE_SWIPE_END"    // gesture
         "\\s+\\S+"                 // timestamp
         "\\s+(\\d+)"               // fingers
-        "\\s*$"                    // trim end of string
+        "$"                        // end of string
     ;
 
     // matches signed decimal numbers (eg. "6.02" "-1.1")
@@ -383,14 +383,14 @@ namespace util {
      *                                          fingers  dx   dy    udx   udy
      */
     const char* GESTURE_SWIPE_UPDATE_REGEX_PATTERN =
-        "^\\s*"                                             // trim start of string
-        "\\s+event\\d+"                                     // event
+        "^"                                                 // start of string
+        "[ -]event\\d+"                                     // event
         "\\s+GESTURE_SWIPE_UPDATE"                          // gesture
         "\\s+\\S+"                                          // timestamp
         "\\s+(\\d+)"                                        // fingers
         "\\s+" CF_NUMBER_DIVISION                           // speed (dx/dy)
         "\\s+\\(" CF_NUMBER_DIVISION "\\s+unaccelerated\\)" // unaccelerated speed (udx/udy)
-        "\\s*$"                                             // trim end of string
+        "$"                                                 // end of string
     ;
 
     // delete macros


### PR DESCRIPTION
Reduces startup hiccup by transforming runtime-built regex into pre-compiled constants.

### Details
Takes advantage of C++ compile-time methods. Removes redundant patterns (eg. `\\s+\\s*`) and unused matches (ie. device, stamp) from `swipe_impl`. Kept the match logic minimal based on output from `libinput debug-events`.

Old:
```cpp
string join(cstr delim, string arr[], int n) {
    string ans = arr[0];
    for (int i = 1; i < n; ++i) {
        ans += delim;
        ans += arr[i];
    }
    return ans;
}
string build_gesture_begin() {
    string device = "\\s*(\\S+)\\s*";
    string gesture = "\\s*GESTURE_SWIPE_BEGIN\\s*";
    string seconds = "\\s*(\\S+)\\s*";
    string fingers = "\\s*(\\d+)\\s*";
    string arr[] = {device, gesture, seconds, fingers};
    return join("\\s+", arr, 4);
}
```

Proposed:
```cpp
// use constant literal instead of string builder
const char* GESTURE_SWIPE_BEGIN_REGEX_PATTERN =
    "^"                        // start of string
    "[ -]event\\d+"            // event
    "\\s+GESTURE_SWIPE_BEGIN"  // gesture
    "\\s+\\S+"                 // timestamp
    "\\s+(\\d+)"               // fingers
    "$"                        // end of string
;
```