### PR TITLE
Derive gestures from xdo_gesture interface

### DIFF
--- a/src/lib/gesture/swipe_gesture.cpp
+++ b/src/lib/gesture/swipe_gesture.cpp
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <iostream> // std::cout, std::endl
 #include "../index.hpp"
+#include "xdo_gesture.h"
 
 extern "C"
 {
@@ -29,122 +30,118 @@ extern "C"
                      // CURRENT_WINDOW
 }
 
-namespace comfortable_swipe
+namespace comfortable_swipe::gesture
 {
-    namespace gesture
+    /**
+     * Constructs a new swipe gesture, given configurations for certain swipe events.
+     */
+    swipe_gesture::swipe_gesture
+    (
+        const float threshold,
+        const char* left3   /* 000 */,
+        const char* left4   /* 001 */,
+        const char* right3  /* 010 */,
+        const char* right4  /* 011 */,
+        const char* up3     /* 100 */,
+        const char* up4     /* 101 */,
+        const char* down3   /* 110 */,
+        const char* down4   /* 111 */
+    ):
+        comfortable_swipe::gesture::xdo_gesture(),
+        commands(new const char*[8]{left3, left4, right3, right4, up3, up4, down3, down4})
+    { }
+
+    /**
+     * Destructs this swipe gesture.
+     */
+    swipe_gesture::~swipe_gesture()
     {
-        /**
-         * Constructs a new swipe gesture with xdo.
-         */
-        swipe_gesture::swipe_gesture
-        (
-            const float threshold,
-            const char* left3   /* 000 */,
-            const char* left4   /* 001 */,
-            const char* right3  /* 010 */,
-            const char* right4  /* 011 */,
-            const char* up3     /* 100 */,
-            const char* up4     /* 101 */,
-            const char* down3   /* 110 */,
-            const char* down4   /* 111 */
-        ):
-            xdo(xdo_new(NULL)),
-            commands(new const char*[8]{left3, left4, right3, right4, up3, up4, down3, down4})
-        { }
+        delete[] commands;
+    }
 
-        /**
-         * Constructs a new swipe gesture with xdo.
-         */
-        swipe_gesture::~swipe_gesture()
-        {
-            xdo_free(this->xdo);
-            delete[] commands;
-        }
+    /**
+     * Hook on begin of swipe gesture.
+     */
+    void swipe_gesture::begin()
+    {
+        xdo_get_mouse_location(this->xdo, &this->ix, &this->iy, &this->screen_num);
+        this->previous_gesture = swipe_gesture::FRESH;
+        this->x = 0;
+        this->y = 0;
+    }
 
-        /**
-         * Hook on begin of swipe gesture.
-         */
-        void swipe_gesture::begin()
+    /**
+     * Hook on update of swipe gesture.
+     */
+    void swipe_gesture::update()
+    {
+        this->x += this->dx;
+        this->y += this->dy;
+        // scale threshold to 1/10 when gesture is not fresh
+        float scale = this->previous_gesture == swipe_gesture::FRESH
+            ? 1.00f
+            : 0.01f; // square root of 1/10
+        if (this->x * this->x + this->y * this->y > this->threshold_squared * scale)
         {
-            xdo_get_mouse_location(this->xdo, &this->ix, &this->iy, &this->screen_num);
-            this->previous_gesture = swipe_gesture::FRESH;
-            this->x = 0;
-            this->y = 0;
-        }
+            int mask = 0;
+            if (this->fingers == 3) mask |= swipe_gesture::MSK_THREE_FINGERS;
+            else if (this->fingers == 4) mask |= swipe_gesture::MSK_FOUR_FINGERS;
 
-        /**
-         * Hook on update of swipe gesture.
-         */
-        void swipe_gesture::update()
-        {
-            this->x += this->dx;
-            this->y += this->dy;
-            // scale threshold to 1/10 when gesture is not fresh
-            float scale = this->previous_gesture == swipe_gesture::FRESH
-                ? 1.00f
-                : 0.01f; // square root of 1/10
-            if (this->x * this->x + this->y * this->y > this->threshold_squared * scale)
+            const float absx = x >= 0 ? x : -x;
+            const float absy = y >= 0 ? y : -y;
+            if (absx > absy)
+            { // horizontal
+                mask |= swipe_gesture::MSK_HORIZONTAL;
+                if (x < 0)
+                    mask |= swipe_gesture::MSK_NEGATIVE;
+                else
+                    mask |= swipe_gesture::MSK_POSITIVE;
+            }
+            else /* std::abs(x) <= std::abs(y) */
+            { // vertical
+                mask |= swipe_gesture::MSK_VERTICAL;
+                if (y < 0)
+                    mask |= swipe_gesture::MSK_NEGATIVE;
+                else
+                    mask |= swipe_gesture::MSK_POSITIVE;
+            }
+
+            // send command on fresh OR opposite gesture
+            if (this->previous_gesture == swipe_gesture::FRESH
+                || this->previous_gesture == (mask ^ swipe_gesture::MSK_POSITIVE))
             {
-                int mask = 0;
-                if (this->fingers == 3) mask |= swipe_gesture::MSK_THREE_FINGERS;
-                else if (this->fingers == 4) mask |= swipe_gesture::MSK_FOUR_FINGERS;
-
-                const float absx = x >= 0 ? x : -x;
-                const float absy = y >= 0 ? y : -y;
-                if (absx > absy)
-                { // horizontal
-                    mask |= swipe_gesture::MSK_HORIZONTAL;
-                    if (x < 0)
-                        mask |= swipe_gesture::MSK_NEGATIVE;
-                    else
-                        mask |= swipe_gesture::MSK_POSITIVE;
-                }
-                else /* std::abs(x) <= std::abs(y) */
-                { // vertical
-                    mask |= swipe_gesture::MSK_VERTICAL;
-                    if (y < 0)
-                        mask |= swipe_gesture::MSK_NEGATIVE;
-                    else
-                        mask |= swipe_gesture::MSK_POSITIVE;
-                }
-
-                // send command on fresh OR opposite gesture
-                if (this->previous_gesture == swipe_gesture::FRESH
-                    || this->previous_gesture == (mask ^ swipe_gesture::MSK_POSITIVE))
-                {
-                    this->x = this->y = 0;
-                    this->previous_gesture = mask;
-                    std::cout << "SWIPE " << swipe_gesture::command_map[mask] << std::endl;
-                    xdo_send_keysequence_window(xdo, CURRENTWINDOW, swipe_gesture::commands[mask], 0);
-                }
+                this->x = this->y = 0;
+                this->previous_gesture = mask;
+                std::cout << "SWIPE " << swipe_gesture::command_map[mask] << std::endl;
+                xdo_send_keysequence_window(xdo, CURRENTWINDOW, swipe_gesture::commands[mask], 0);
             }
         }
-
-        /**
-         * Hook on end of swipe gesture.
-         */
-        void swipe_gesture::end()
-        { }
-
-        /* STATICS DEFINITIONS */
-        const int swipe_gesture::MSK_THREE_FINGERS = 0;
-        const int swipe_gesture::MSK_FOUR_FINGERS = 1;
-        const int swipe_gesture::MSK_NEGATIVE = 0;
-        const int swipe_gesture::MSK_POSITIVE = 2;
-        const int swipe_gesture::MSK_HORIZONTAL = 0;
-        const int swipe_gesture::MSK_VERTICAL = 4;
-        const int swipe_gesture::FRESH = -1;
-        const char * const swipe_gesture::command_map[8] = {
-            "left 3",
-            "left 4",
-            "right 3",
-            "right 4",
-            "up 3",
-            "up 4",
-            "down 3",
-            "down 4"
-        };
     }
+
+    /**
+     * Hook on end of swipe gesture.
+     */
+    void swipe_gesture::end()
+    { }
+
+    /* STATICS DEFINITIONS */
+    const int swipe_gesture::MSK_THREE_FINGERS = 0;
+    const int swipe_gesture::MSK_FOUR_FINGERS = 1;
+    const int swipe_gesture::MSK_NEGATIVE = 0;
+    const int swipe_gesture::MSK_POSITIVE = 2;
+    const int swipe_gesture::MSK_HORIZONTAL = 0;
+    const int swipe_gesture::MSK_VERTICAL = 4;
+    const int swipe_gesture::FRESH = -1;
+    const char * const swipe_gesture::command_map[8] = {
+        "left 3",
+        "left 4",
+        "right 3",
+        "right 4",
+        "up 3",
+        "up 4",
+        "down 3",
+        "down 4"
+    };
 }
 
 #endif /* __COMFORTABLE_SWIPE__gesture_swipe_gesture__ */

--- a/src/lib/gesture/swipe_gesture.h
+++ b/src/lib/gesture/swipe_gesture.h
@@ -24,60 +24,60 @@ extern "C"
     #include <xdo.h> // xdo_t
 }
 
+#include "xdo_gesture.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-namespace comfortable_swipe
+namespace comfortable_swipe::gesture
 {
-    namespace gesture
+    class swipe_gesture : protected xdo_gesture
     {
-        struct swipe_gesture
-        {
-            // constructor
-            swipe_gesture(
-                const float,
-                const char*,
-                const char*,
-                const char*,
-                const char*,
-                const char*,
-                const char*,
-                const char*,
-                const char*
-            );
+    public:
+        // constructor
+        swipe_gesture(
+            const float threshold,
+            const char* left3   /* 000 */,
+            const char* left4   /* 001 */,
+            const char* right3  /* 010 */,
+            const char* right4  /* 011 */,
+            const char* up3     /* 100 */,
+            const char* up4     /* 101 */,
+            const char* down3   /* 110 */,
+            const char* down4   /* 111 */
+        );
 
-            ~swipe_gesture();
+        ~swipe_gesture();
 
-            // fields for xdo
-            int fingers;
-            float dx, dy, udx, udy;
-            xdo_t * xdo;
-            
-            // location of mouse
-            int screen_num, ix, iy;
+        // fields for xdo
+        int fingers;
+        float dx, dy, udx, udy;
 
-            // current location
-            float x, y, threshold_squared;
-            int previous_gesture;
-            const char ** commands;
+        void begin() override;
+        void update() override;
+        void end() override;
+        
+    protected:
+        // location of mouse
+        int screen_num, ix, iy;
 
-            // hooks
-            void update();
-            void begin();
-            void end();
+        // current location
+        float x, y, threshold_squared;
+        int previous_gesture;
+        const char ** commands;
 
-            // statics
-            static const int MSK_THREE_FINGERS;
-            static const int MSK_FOUR_FINGERS;
-            static const int MSK_NEGATIVE;
-            static const int MSK_POSITIVE;
-            static const int MSK_HORIZONTAL;
-            static const int MSK_VERTICAL;
-            static const int FRESH;
-            static const char * const command_map[8];
-        };
-    }
+    public:
+        // static constants
+        static const int MSK_THREE_FINGERS;
+        static const int MSK_FOUR_FINGERS;
+        static const int MSK_NEGATIVE;
+        static const int MSK_POSITIVE;
+        static const int MSK_HORIZONTAL;
+        static const int MSK_VERTICAL;
+        static const int FRESH;
+        static const char * const command_map[8];
+    };
 }
 
 #ifdef __cplusplus

--- a/src/lib/gesture/xdo_gesture.cpp
+++ b/src/lib/gesture/xdo_gesture.cpp
@@ -1,5 +1,5 @@
-#ifndef __COMFORTABLE_SWIPE__
-#define __COMFORTABLE_SWIPE__
+#ifndef __COMFORTABLE_SWIPE__xdo_gesture__
+#define __COMFORTABLE_SWIPE__xdo_gesture__
 
 /*
 Comfortable Swipe
@@ -19,23 +19,27 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "index.hpp"
+extern "C"
+{
+    #include <xdo.h> // xdo, xdo_new
+}
 
-/**
- * Make sure to include all implementation (.cpp) files below to be ready for export.
- */
+namespace comfortable_swipe::gesture
+{
+    /**
+     * Constructs a new gesture handler with xdo.
+     */
+    xdo_gesture::xdo_gesture():
+        xdo(xdo_new(NULL))
+    { }
 
-#include "gesture/xdo_gesture.cpp"
-#include "gesture/swipe_gesture.cpp"
-#include "service/autostart.cpp"
-#include "service/buffer.cpp"
-#include "service/help.cpp"
-#include "service/restart.cpp"
-#include "service/start.cpp"
-#include "service/stop.cpp"
-#include "util/autostart_filename.cpp"
-#include "util/conf_filename.cpp"
-#include "util/read_config_file.cpp"
-#include "util/regex.cpp"
+    /**
+     * Constructs a new swipe gesture with xdo.
+     */
+    xdo_gesture::~xdo_gesture()
+    {
+        xdo_free(this->xdo);
+    }
+}
 
-#endif /* __COMFORTABLE_SWIPE__ */
+#endif /* __COMFORTABLE_SWIPE__xdo_gesture__ */

--- a/src/lib/gesture/xdo_gesture.h
+++ b/src/lib/gesture/xdo_gesture.h
@@ -1,5 +1,5 @@
-#ifndef __COMFORTABLE_SWIPE__
-#define __COMFORTABLE_SWIPE__
+#ifndef __COMFORTABLE_SWIPE__xdo_gesture_h__
+#define __COMFORTABLE_SWIPE__xdo_gesture_h__
 
 /*
 Comfortable Swipe
@@ -19,23 +19,38 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "index.hpp"
+extern "C"
+{
+    #include <xdo.h> // xdo_t
+}
 
-/**
- * Make sure to include all implementation (.cpp) files below to be ready for export.
- */
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#include "gesture/xdo_gesture.cpp"
-#include "gesture/swipe_gesture.cpp"
-#include "service/autostart.cpp"
-#include "service/buffer.cpp"
-#include "service/help.cpp"
-#include "service/restart.cpp"
-#include "service/start.cpp"
-#include "service/stop.cpp"
-#include "util/autostart_filename.cpp"
-#include "util/conf_filename.cpp"
-#include "util/read_config_file.cpp"
-#include "util/regex.cpp"
+namespace comfortable_swipe
+{
+    namespace gesture
+    {
+        class xdo_gesture
+        {
+        protected:
+            xdo_t * xdo;
 
-#endif /* __COMFORTABLE_SWIPE__ */
+        public:
+            xdo_gesture();
+            ~xdo_gesture();
+
+            // hooks
+            virtual void begin() = 0;
+            virtual void update() = 0;
+            virtual void end() = 0;
+        };
+    }
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __COMFORTABLE_SWIPE__xdo_gesture_h__ */

--- a/src/lib/index.hpp
+++ b/src/lib/index.hpp
@@ -34,6 +34,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 /**
  * Make sure to include your header files here so that they can be imported by other modules.
  */
+#include "gesture/xdo_gesture.h"
 #include "gesture/swipe_gesture.h"
 extern "C"
 {


### PR DESCRIPTION
Have an interface for gestures called `comfortable_swipe::gesture::xdo_gestures` that can easily be extended by another gesture model.