### PR TITLE
Fix bug in restart service

### DIFF
--- a/src/lib/service/restart.cpp
+++ b/src/lib/service/restart.cpp
@@ -28,8 +28,8 @@ namespace comfortable_swipe::service
      */
     void restart()
     {
-        comfortable_swipe::service::start();
         comfortable_swipe::service::stop();
+        comfortable_swipe::service::start();
     }
 }
 


### PR DESCRIPTION
_Buggy behavior_: restart calls **start** then **stop**

_Expected_: restart should **stop** then **start**
