### PR TITLE
Improve responsiveness of initial gesture

### DIFF
--- a/src/lib/gesture/swipe_gesture.cpp
+++ b/src/lib/gesture/swipe_gesture.cpp
@@ -49,7 +49,10 @@ namespace comfortable_swipe::gesture
         comfortable_swipe::gesture::xdo_gesture(),
         threshold_squared(threshold*threshold),
         commands(new const char*[8]{left3, left4, right3, right4, up3, up4, down3, down4})
-    { }
+    {
+        // improve responsiveness of first gesture by pre-empting xdotool runtime
+        xdo_get_mouse_location(this->xdo, &this->ix, &this->iy, &this->screen_num);
+    }
 
     /**
      * Destructs this swipe gesture.


### PR DESCRIPTION
According to #30, first gesture has a few seconds delay for some users. It has been found that the problem lies in `xdotool` "lazy-loading" modules before a first gesture.

#### The Fix
This PR preloads `xdotool` by binding it on construction to eagerly load modules.

#### How to Test
```bash
# clone this branch
git clone https://github.com/Hikari9/comfortable-swipe-ubuntu --branch improve-first-gesture-responsiveness

# Go to this folder and install (will replace current comfortable-swipe)
cd comfortable-swipe-ubuntu
bash install

# Run
comfortable-swipe start
```