### PR TITLE
Decouple buffer from gesture handler

### DIFF
--- a/lib/gesture/swipe_gesture.h
+++ b/lib/gesture/swipe_gesture.h
@@ -52,7 +52,8 @@ namespace comfortable_swipe::gesture
         void begin() override;
         void update() override;
         void end() override;
-        
+        bool parse_line(const char *) override;
+
     protected:
         // location of mouse
         int screen_num, ix, iy;
@@ -61,6 +62,9 @@ namespace comfortable_swipe::gesture
         float x, y, threshold_squared;
         int previous_gesture;
         const char ** commands;
+
+        // optimization flag for checking if GESTURE_SWIPE_BEGIN was dispatched
+        bool flag_swiping;
 
     public:
         // static constants

--- a/lib/gesture/xdo_gesture.h
+++ b/lib/gesture/xdo_gesture.h
@@ -45,6 +45,7 @@ namespace comfortable_swipe
             virtual void begin() = 0;
             virtual void update() = 0;
             virtual void end() = 0;
+            virtual bool parse_line(const char *) = 0;
         };
     }
 }

--- a/lib/service/buffer.cpp
+++ b/lib/service/buffer.cpp
@@ -19,9 +19,7 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <string> // std::stoi, std::stof
 #include <cstdio> // std::fgets_unlocked, stdin
-#include <regex> // std::regex, std::regex_match, std::cmatch
 #include "../index.hpp"
 
 /**
@@ -34,13 +32,8 @@ namespace comfortable_swipe::service
         // read config file
         auto config = comfortable_swipe::util::read_config_file(comfortable_swipe::util::conf_filename());
 
-        // pre-compile regex patterns
-        static const std::regex gesture_swipe_begin(comfortable_swipe::gesture::swipe_gesture::GESTURE_BEGIN_REGEX_PATTERN);
-        static const std::regex gesture_swipe_update(comfortable_swipe::gesture::swipe_gesture::GESTURE_UPDATE_REGEX_PATTERN);
-        static const std::regex gesture_swipe_end(comfortable_swipe::gesture::swipe_gesture::GESTURE_END_REGEX_PATTERN);
-
         // initialize swipe gesture handler
-        comfortable_swipe::gesture::swipe_gesture swipe
+        comfortable_swipe::gesture::swipe_gesture swipe_gesture_handler
         (
             config.count("threshold") ? std::stof(config["threshold"]) : 0.0,
             config["left3"].c_str(),
@@ -56,47 +49,12 @@ namespace comfortable_swipe::service
         // prepare data containers
         static const int MAX_LINE_LENGTH = 256;
         static char data[MAX_LINE_LENGTH];
-        static std::cmatch matches;
-
-        // optimization flag for checking if GESTURE_SWIPE_BEGIN was dispatched
-        bool flag_swiping = false;
 
         // start reading lines from input one by one
         while (fgets_unlocked(data, MAX_LINE_LENGTH, stdin) != NULL)
         {
-            if (flag_swiping)
-            {
-                // currently swiping
-                if (std::regex_match(data, matches, gesture_swipe_update) != 0)
-                {
-                    // update swipe
-                    swipe.fingers = std::stoi(matches[1]);
-                    swipe.dx = std::stof(matches[2]);
-                    swipe.dy = std::stof(matches[3]);
-                    swipe.udx = std::stof(matches[4]);
-                    swipe.udy = std::stof(matches[5]);
-                    swipe.update();
-                }
-                else if (std::regex_match(data, matches, gesture_swipe_end) != 0)
-                {
-                    // end swipe
-                    flag_swiping = false;
-                    swipe.fingers = std::stoi(matches[1]);
-                    swipe.end();
-                }
-            }
-            else /* !flag_swiping */
-            {
-                // not swiping, check if swipe will begin
-                if (std::regex_match(data, matches, gesture_swipe_begin) != 0)
-                {
-                    // begin swipe
-                    flag_swiping = true;
-                    swipe.fingers = std::stoi(matches[1]);
-                    swipe.begin();
-                }
-            }
-            
+            // attempt to parse swipe gestures
+            swipe_gesture_handler.parse_line(data);
         }
     }
 }


### PR DESCRIPTION
Previously, `comfortable_swipe::service::buffer` handles the dispatching of gesture events taken from `libinput debug-events`. This is proposed to be moved to `comfortable_swipe::gesture::swipe_gesture::parse_line` for better decoupling of functionality from input parsing. 