### PR TITLE
Print abort() echo 'Installation aborted' to stdout. Allow \n (ENTER)…

### DIFF
--- a/install
+++ b/install
@@ -67,16 +67,23 @@ function install_configuration_file {
         # ask user if we overwrite configuration
         echo "Old conf file found in $CONF_TARGET" >&2
         read -r -p "Keep the old conf file? (default: yes) [Y/n] " response >&2
-        if ! [[ "${response,,}" =~ ^(no|n)$ ]] || [[ "$response" == "" ]]; then
-			continue
-		else
+
+        # If response is empty, consider it as 'yes' (default)
+		if [[ -z "$response" ]]; then
+            response="y"
+        fi
+
+        if [[ "${response,,}" =~ ^(no|n)$ ]]; then
             # MAKE SURE they really want to overwrite
             read -r -p "Conf file will be overwritten! Are you sure? [Y/n] " response >&2
-        	if ! [[ "${response,,}" =~ ^(no|n)$ ]] || [[ "$response" == "" ]]; then
+			if [[ -z "$response" ]]; then
+				response="y"
+			fi
+        	if [[ "${response,,}" =~ ^(no|n)$ ]]; then
+                abort
+            else
                 # They agreed... replace configuration
                 cat "$CONF_SOURCE" > "$CONF_TARGET"
-            else
-                abort
             fi
         fi
     else

--- a/install
+++ b/install
@@ -34,7 +34,7 @@ comfortable-swipe stop > /dev/null 2>&1 || true
 
 # shorthand to abort the installation
 function abort {
-    echo "Installation aborted"
+    echo "Installation aborted" >&2 
     exit 1
 }
 
@@ -67,10 +67,12 @@ function install_configuration_file {
         # ask user if we overwrite configuration
         echo "Old conf file found in $CONF_TARGET" >&2
         read -r -p "Keep the old conf file? (default: yes) [Y/n] " response >&2
-        if ! [[ "${response,,}" =~ ^(yes|y)$ ]]; then
+        if ! [[ "${response,,}" =~ ^(no|n)$ ]] || [[ "$response" == "" ]]; then
+			continue
+		else
             # MAKE SURE they really want to overwrite
             read -r -p "Conf file will be overwritten! Are you sure? [Y/n] " response >&2
-            if [[ "${response,,}" =~ ^(yes|y)$ ]]; then
+        	if ! [[ "${response,,}" =~ ^(no|n)$ ]] || [[ "$response" == "" ]]; then
                 # They agreed... replace configuration
                 cat "$CONF_SOURCE" > "$CONF_TARGET"
             else


### PR DESCRIPTION
Print abort() echo 'Installation aborted' to stdout. Allow \n (ENTER) to be the printed default: yes.

2 Changes to the install script.

1. `function abort`
> Former behavior:
> `function abort` did not print the `echo "Installation aborted"` to stdout.
> New behavior:
> `function abort` prints "Installation aborted" to stdout.


2. When asking the user if we overwrite the configuration, `(default: yes)` is offered.
> Former behavior:
> Hitting ENTER (\n) triggers `function abort`.
> New behavior:
> Hitting ENTER (\n) is accepted as 'yes'.


Here are testing logs from trying this in Docker containers of ubuntu:18.04 and ubuntu:22.04.
[comfortable-swipe_ubuntu18.04.log](https://github.com/Hikari9/comfortable-swipe/files/12250430/comfortable-swipe_ubuntu18.04.log)
[comfortable-swipe_ubuntu22.04.log](https://github.com/Hikari9/comfortable-swipe/files/12250431/comfortable-swipe_ubuntu22.04.log)
